### PR TITLE
Add wake lock toggle to extension popup

### DIFF
--- a/content/config.json
+++ b/content/config.json
@@ -2,7 +2,7 @@
   "settings": {
     "processInterval": 100,
     "maxRetries": 0,
-    "debug": true,
+    "debug": false,
     "showDemoIndicator": false
   },
   "urlPatterns": {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -182,6 +182,11 @@
       <div class="toggle-switch" id="toggleSwitch"></div>
     </div>
     
+    <div class="toggle-container">
+      <span class="toggle-label">Keep screen awake</span>
+      <div class="toggle-switch" id="wakeLockSwitch"></div>
+    </div>
+    
     <div class="status loading" id="status">
       Loading extension status...
     </div>


### PR DESCRIPTION
Introduces a 'Keep screen awake' toggle in the popup UI and supporting logic in background and popup scripts. Wake lock state is now stored in extension storage and can be updated from the popup, allowing users to prevent the screen from sleeping while the extension is active. Also disables debug mode in config.json.